### PR TITLE
enable syntax highlighting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! Let's have a look at a small example.
 //!
-//! ```run
+//! ```rust
 //! #[tracker::track]
 //! struct Test {
 //!     x: u8,


### PR DESCRIPTION
shouldn't it not `rust` instead of `run`